### PR TITLE
Fix Bundler warning and Bump version to 0.2.2

### DIFF
--- a/mixable_engines.gemspec
+++ b/mixable_engines.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{mixable_engines}
-  s.version = "0.1.1"
+  s.version = "0.2.2"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Tim Morton"]
@@ -16,13 +16,13 @@ Gem::Specification.new do |s|
   s.email = %q{tim@timothymorton.com}
   s.extra_rdoc_files = [
     "LICENSE.txt",
-    "README.rdoc"
+    "README.md"
   ]
   s.files = [
     ".document",
     "Gemfile",
     "LICENSE.txt",
-    "README.rdoc",
+    "README.md",
     "Rakefile",
     "VERSION",
     "lib/mixable_engines.rb",


### PR DESCRIPTION
original warning messages:

```
mixable_engines at ~/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/bundler/gems/mixable_engines-42ef43258196 did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  ["README.rdoc"] are not files
```
